### PR TITLE
Bounds-check encap request slot IDs

### DIFF
--- a/doc/api/responder_api.md
+++ b/doc/api/responder_api.md
@@ -434,7 +434,8 @@ The SPDM context.
 The `session_id` given to `libspdm_encap_flow_handler_func`.
 
 **slot_id**<br/>
-The slot of the Requester's certificate chain to be retrieved.
+The slot of the Requester's certificate chain to be retrieved, which is less than
+`SPDM_MAX_SLOT_COUNT`.
 
 **cert_chain_max_size**<br/>
 The size, in bytes, of `cert_chain`.
@@ -458,7 +459,7 @@ entire chain has been retrieved.
 the call itself. A local variable of the function that calls
 `libspdm_responder_dispatch_message`, or a member of the Integrator's own per-connection state, is
 suitable; a local variable of the handler is not. Returns `LIBSPDM_STATUS_INVALID_PARAMETER` if
-`cert_chain` is NULL or `cert_chain_max_size` is 0.
+`cert_chain` is NULL, `cert_chain_max_size` is 0, or `slot_id` is not a valid slot.
 <br/><br/>
 
 
@@ -506,7 +507,8 @@ Populates the buffer with an encapsulated `CHALLENGE` request.
 The SPDM context.
 
 **req_slot_id**<br/>
-The slot of the Requester's certificate chain to be authenticated against.
+The slot of the Requester's certificate chain to be authenticated against, or 0xFF if the
+Requester's public key was provisioned.
 
 **requester_context**<br/>
 For SPDM 1.3 and above, a buffer of `SPDM_REQ_CONTEXT_SIZE` bytes holding the `Context` field, or
@@ -522,7 +524,8 @@ A pointer to a buffer that will store the encapsulated request.
 ### Details
 This is only legal in the basic mutual authentication flow, whose messages are always sent outside
 of a session. libspdm terminates the flow once the encapsulated `CHALLENGE_AUTH` response has been
-delivered.
+delivered. Returns `LIBSPDM_STATUS_INVALID_PARAMETER` if `req_slot_id` is neither a valid slot nor
+0xFF.
 <br/><br/>
 
 
@@ -578,7 +581,8 @@ The `session_id` given to `libspdm_encap_flow_handler_func`.
 The `SubCode` of the request.
 
 **slot_id**<br/>
-The slot of the Requester's certificate chain used to sign the response.
+The slot of the Requester's certificate chain used to sign the response, or 0xF if the Requester's
+public key was provisioned. It is only meaningful when a signature is requested.
 
 **request_attributes**<br/>
 `SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED` to request a signature, otherwise 0.
@@ -606,7 +610,8 @@ is read with `libspdm_get_encap_payload_size`. `ep_info` shall therefore remain 
 handler is next called, which is longer than the call itself. A local variable of the function that
 calls `libspdm_responder_dispatch_message`, or a member of the Integrator's own per-connection
 state, is suitable; a local variable of the handler is not. Returns
-`LIBSPDM_STATUS_INVALID_PARAMETER` if `ep_info` is NULL or `ep_info_max_size` is 0.
+`LIBSPDM_STATUS_INVALID_PARAMETER` if `ep_info` is NULL, `ep_info_max_size` is 0, or `slot_id` is
+neither a valid slot nor 0xF.
 <br/><br/>
 If the Requester returns more endpoint information than `ep_info` can hold then the response is not
 accepted and the encapsulated flow is terminated, in the same way as an oversized certificate chain.

--- a/include/library/spdm_responder_lib.h
+++ b/include/library/spdm_responder_lib.h
@@ -325,7 +325,8 @@ libspdm_return_t libspdm_get_encap_request_get_digests(void *spdm_context,
  *
  * @param  spdm_context         A pointer to the SPDM context.
  * @param  session_id           The session_id given to libspdm_encap_flow_handler_func.
- * @param  slot_id              The slot of the Requester's certificate chain to be retrieved.
+ * @param  slot_id              The slot of the Requester's certificate chain to be retrieved,
+ *                              which is less than SPDM_MAX_SLOT_COUNT.
  * @param  cert_chain_max_size  The size, in bytes, of cert_chain.
  * @param  cert_chain           A pointer to a buffer that will store the certificate chain.
  * @param  encap_request_size   On input, the size in bytes of the encapsulated request buffer.
@@ -333,7 +334,8 @@ libspdm_return_t libspdm_get_encap_request_get_digests(void *spdm_context,
  * @param  encap_request        A pointer to the encapsulated request data.
  *
  * @retval LIBSPDM_STATUS_SUCCESS            The encapsulated request is returned.
- * @retval LIBSPDM_STATUS_INVALID_PARAMETER  cert_chain is NULL or cert_chain_max_size is 0.
+ * @retval LIBSPDM_STATUS_INVALID_PARAMETER  cert_chain is NULL, cert_chain_max_size is 0, or
+ *                                           slot_id is not a valid slot.
  **/
 libspdm_return_t libspdm_get_encap_request_get_certificate(void *spdm_context,
                                                            const uint32_t *session_id,
@@ -361,6 +363,7 @@ libspdm_return_t libspdm_get_encap_request_get_certificate(void *spdm_context,
  *
  * @retval RETURN_SUCCESS               The encapsulated request is returned.
  * @retval RETURN_BUFFER_TOO_SMALL      The buffer is too small to hold the data.
+ * @retval LIBSPDM_STATUS_INVALID_PARAMETER  req_slot_id is neither a valid slot nor 0xFF.
  **/
 libspdm_return_t libspdm_get_encap_request_challenge(void *spdm_context,
                                                      uint8_t req_slot_id,
@@ -408,7 +411,9 @@ libspdm_return_t libspdm_get_encap_request_key_update(void *spdm_context,
  * @param  spdm_context        A pointer to the SPDM context.
  * @param  session_id          The session_id given to libspdm_encap_flow_handler_func.
  * @param  sub_code            Subcode for the GET_ENDPOINT_INFO request.
- * @param  slot_id             Slot ID to include in the request.
+ * @param  slot_id             The slot of the Requester's certificate chain that signs the
+ *                             response, or 0xF if its public key was provisioned. It is only
+ *                             meaningful when a signature is requested.
  * @param  request_attributes  Request attributes; set
  *                             SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED
  *                             to request a signature.
@@ -419,7 +424,8 @@ libspdm_return_t libspdm_get_encap_request_key_update(void *spdm_context,
  * @param  encap_request       Buffer to receive the encapsulated request.
  *
  * @retval LIBSPDM_STATUS_SUCCESS            The encapsulated request is returned.
- * @retval LIBSPDM_STATUS_INVALID_PARAMETER  ep_info is NULL or ep_info_max_size is 0.
+ * @retval LIBSPDM_STATUS_INVALID_PARAMETER  ep_info is NULL, ep_info_max_size is 0, or slot_id
+ *                                           is neither a valid slot nor 0xF.
  **/
 libspdm_return_t libspdm_get_encap_request_get_endpoint_info(
     void *spdm_context,

--- a/library/spdm_responder_lib/libspdm_rsp_encap_challenge.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_challenge.c
@@ -23,6 +23,12 @@ libspdm_return_t libspdm_get_encap_request_challenge(void *context,
 
     spdm_context = context;
 
+    if ((req_slot_id >= SPDM_MAX_SLOT_COUNT) && (req_slot_id != 0xFF)) {
+        /* 0xFF designates the Requester's provisioned public key. Any other slot indexes per-slot
+         * state of SPDM_MAX_SLOT_COUNT entries, which CHALLENGE_AUTH is verified against. */
+        return LIBSPDM_STATUS_INVALID_PARAMETER;
+    }
+
     encap_context = libspdm_get_encap_context_via_last_request(spdm_context);
 
     encap_context->last_encap_request_size = 0;

--- a/library/spdm_responder_lib/libspdm_rsp_encap_get_certificate.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_get_certificate.c
@@ -25,6 +25,13 @@ libspdm_return_t libspdm_get_encap_request_get_certificate(void *context,
         return LIBSPDM_STATUS_INVALID_PARAMETER;
     }
 
+    if (req_slot_id >= SPDM_MAX_SLOT_COUNT) {
+        /* The slot indexes per-slot state of SPDM_MAX_SLOT_COUNT entries, in which the
+         * Requester's certificate chain is recorded once retrieved. GET_CERTIFICATE has no slot
+         * value that designates a provisioned public key. */
+        return LIBSPDM_STATUS_INVALID_PARAMETER;
+    }
+
     encap_context = libspdm_get_encap_context(spdm_context, session_id);
     if (encap_context == NULL) {
         /* session_id does not refer to an existing session. */

--- a/library/spdm_responder_lib/libspdm_rsp_encap_get_endpoint_info.c
+++ b/library/spdm_responder_lib/libspdm_rsp_encap_get_endpoint_info.c
@@ -33,6 +33,13 @@ libspdm_return_t libspdm_get_encap_request_get_endpoint_info(
         return LIBSPDM_STATUS_INVALID_PARAMETER;
     }
 
+    if ((slot_id >= SPDM_MAX_SLOT_COUNT) && (slot_id != 0xF)) {
+        /* SlotID is a four-bit field in which 0xF designates the Requester's provisioned public
+         * key. Any other slot indexes per-slot state of SPDM_MAX_SLOT_COUNT entries, which
+         * ENDPOINT_INFO is verified against. */
+        return LIBSPDM_STATUS_INVALID_PARAMETER;
+    }
+
     encap_context = libspdm_get_encap_context(spdm_context, session_id);
     if (encap_context == NULL) {
         /* session_id does not refer to an existing session. */

--- a/unit_test/test_spdm_responder/encap_challenge.c
+++ b/unit_test/test_spdm_responder/encap_challenge.c
@@ -539,6 +539,63 @@ static void rsp_encap_challenge_case7(void **state)
                         SPDM_REQ_CONTEXT_SIZE);
 }
 
+/**
+ * Test 8: the slot of the Requester's certificate chain is bounds-checked.
+ * Expected Behavior: a slot that is not less than SPDM_MAX_SLOT_COUNT is rejected with
+ * LIBSPDM_STATUS_INVALID_PARAMETER before anything is recorded, as CHALLENGE_AUTH would otherwise
+ * be verified against per-slot state that has no such entry. 0xFF, which designates the
+ * Requester's provisioned public key, and the highest valid slot are accepted and placed in the
+ * request.
+ **/
+static void rsp_encap_challenge_case8(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    const spdm_challenge_request_t *spdm_request;
+    uint8_t encap_request[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    size_t encap_request_size;
+    size_t index;
+    const uint8_t invalid_slot_id[] = { SPDM_MAX_SLOT_COUNT, 0xF, 0xFE };
+    const uint8_t valid_slot_id[] = { SPDM_MAX_SLOT_COUNT - 1, 0xFF };
+
+    spdm_test_context = *state;
+    spdm_context = spdm_test_context->spdm_context;
+
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_12 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags = 0;
+    spdm_context->connection_info.capability.flags |= SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CHAL_CAP;
+    spdm_context->last_spdm_request_session_id_valid = false;
+
+    for (index = 0; index < LIBSPDM_ARRAY_SIZE(invalid_slot_id); index++) {
+        spdm_context->encap_context.req_slot_id = 0;
+
+        encap_request_size = sizeof(encap_request);
+        status = libspdm_get_encap_request_challenge(spdm_context, invalid_slot_id[index], NULL,
+                                                     &encap_request_size, encap_request);
+        assert_int_equal(status, LIBSPDM_STATUS_INVALID_PARAMETER);
+
+        /* The slot was not recorded. */
+        assert_int_equal(spdm_context->encap_context.req_slot_id, 0);
+    }
+
+    for (index = 0; index < LIBSPDM_ARRAY_SIZE(valid_slot_id); index++) {
+        libspdm_reset_message_mut_c(spdm_context);
+
+        encap_request_size = sizeof(encap_request);
+        status = libspdm_get_encap_request_challenge(spdm_context, valid_slot_id[index], NULL,
+                                                     &encap_request_size, encap_request);
+        assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+        spdm_request = (const void *)encap_request;
+        assert_int_equal(spdm_request->header.param1, valid_slot_id[index]);
+        assert_int_equal(spdm_context->encap_context.req_slot_id, valid_slot_id[index]);
+    }
+
+    spdm_context->encap_context.req_slot_id = 0;
+}
+
 int libspdm_rsp_encap_challenge_test(void)
 {
     const struct CMUnitTest test_cases[] = {
@@ -555,6 +612,8 @@ int libspdm_rsp_encap_challenge_test(void)
         cmocka_unit_test(rsp_encap_challenge_case6),
         /* The RequesterContext that is sent is also recorded in the encapsulated context */
         cmocka_unit_test(rsp_encap_challenge_case7),
+        /* The slot of the Requester's certificate chain is bounds-checked */
+        cmocka_unit_test(rsp_encap_challenge_case8),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/encap_get_certificate.c
+++ b/unit_test/test_spdm_responder/encap_get_certificate.c
@@ -653,6 +653,65 @@ static void rsp_encap_get_certificate_case6(void **state)
     spdm_context->encap_context.payload_buffer_size = 0;
 }
 
+/**
+ * Test 7: the slot of the Requester's certificate chain is bounds-checked.
+ * Expected Behavior: a slot that is not less than SPDM_MAX_SLOT_COUNT is rejected with
+ * LIBSPDM_STATUS_INVALID_PARAMETER before anything is recorded, as the CERTIFICATE response would
+ * otherwise be recorded in per-slot state that has no such entry. GET_CERTIFICATE has no slot value
+ * that designates a provisioned public key, so 0xFF is rejected too. The highest valid slot is
+ * accepted and placed in the request.
+ **/
+static void rsp_encap_get_certificate_case7(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    const spdm_get_certificate_request_t *spdm_request;
+    uint8_t encap_request[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    uint8_t cert_chain[LIBSPDM_MAX_CERT_CHAIN_SIZE];
+    size_t encap_request_size;
+    size_t index;
+    const uint8_t invalid_slot_id[] = { SPDM_MAX_SLOT_COUNT, 0xF, 0xFF };
+
+    spdm_test_context = *state;
+    spdm_test_context->case_id = 0x7;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_11 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_CERT_CAP;
+    spdm_context->last_spdm_request_session_id_valid = false;
+
+    for (index = 0; index < LIBSPDM_ARRAY_SIZE(invalid_slot_id); index++) {
+        spdm_context->encap_context.req_slot_id = 0;
+        spdm_context->encap_context.payload_buffer = NULL;
+
+        encap_request_size = sizeof(encap_request);
+        status = libspdm_get_encap_request_get_certificate(
+            spdm_context, NULL, invalid_slot_id[index], sizeof(cert_chain), cert_chain,
+            &encap_request_size, encap_request);
+        assert_int_equal(status, LIBSPDM_STATUS_INVALID_PARAMETER);
+
+        /* Neither the slot nor the buffer was recorded. */
+        assert_int_equal(spdm_context->encap_context.req_slot_id, 0);
+        assert_null(spdm_context->encap_context.payload_buffer);
+    }
+
+    encap_request_size = sizeof(encap_request);
+    status = libspdm_get_encap_request_get_certificate(
+        spdm_context, NULL, SPDM_MAX_SLOT_COUNT - 1, sizeof(cert_chain), cert_chain,
+        &encap_request_size, encap_request);
+    assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+    spdm_request = (const void *)encap_request;
+    assert_int_equal(spdm_request->header.param1, SPDM_MAX_SLOT_COUNT - 1);
+    assert_int_equal(spdm_context->encap_context.req_slot_id, SPDM_MAX_SLOT_COUNT - 1);
+
+    spdm_context->encap_context.req_slot_id = 0;
+    spdm_context->encap_context.payload_buffer = NULL;
+    spdm_context->encap_context.payload_buffer_size = 0;
+}
+
 int libspdm_rsp_encap_get_certificate_test(void)
 {
     const struct CMUnitTest test_cases[] = {
@@ -671,6 +730,8 @@ int libspdm_rsp_encap_get_certificate_test(void)
         cmocka_unit_test(rsp_encap_get_certificate_case5),
         /* Integrator-supplied certificate chain buffer and its size getter */
         cmocka_unit_test(rsp_encap_get_certificate_case6),
+        /* The slot of the Requester's certificate chain is bounds-checked */
+        cmocka_unit_test(rsp_encap_get_certificate_case7),
     };
 
     libspdm_test_context_t test_context = {

--- a/unit_test/test_spdm_responder/encap_get_endpoint_info.c
+++ b/unit_test/test_spdm_responder/encap_get_endpoint_info.c
@@ -191,7 +191,7 @@ static void rsp_encap_get_endpoint_info_case1(void **state)
 }
 
 /**
- * Test 2: Normal case, request a endpoint info with signature, req_slot_id = 0xFF
+ * Test 2: Normal case, request a endpoint info with signature, req_slot_id = 0xF
  * Expected Behavior: get a LIBSPDM_STATUS_SUCCESS return code, correct endpoint_info
  *                    and an empty transcript.message_encap_e
  **/
@@ -231,7 +231,7 @@ static void rsp_encap_get_endpoint_info_case2(void **state)
     spdm_context->local_context.peer_public_key_provision = data;
     spdm_context->local_context.peer_public_key_provision_size = data_size;
 
-    spdm_context->encap_context.req_slot_id = 0xFF;
+    spdm_context->encap_context.req_slot_id = 0xF;
     spdm_context->encap_context.req_attributes =
         SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED;
     endpoint_info_size = LIBSPDM_TEST_ENDPOINT_INFO_BUFFER_SIZE;
@@ -688,12 +688,80 @@ static void rsp_encap_get_endpoint_info_case7(void **state)
     spdm_context->encap_context.payload_buffer_max_size = sizeof(m_endpoint_info_buffer_send);
 }
 
+/**
+ * Test 8: the slot of the Requester's certificate chain is bounds-checked.
+ * Expected Behavior: a slot that is not less than SPDM_MAX_SLOT_COUNT is rejected with
+ * LIBSPDM_STATUS_INVALID_PARAMETER before anything is recorded, as ENDPOINT_INFO would otherwise be
+ * verified against per-slot state that has no such entry. SlotID is a four-bit field, so 0xFF is
+ * rejected too. 0xF, which designates the Requester's provisioned public key, and the highest valid
+ * slot are accepted and placed in the request.
+ **/
+static void rsp_encap_get_endpoint_info_case8(void **state)
+{
+    libspdm_return_t status;
+    libspdm_test_context_t *spdm_test_context;
+    libspdm_context_t *spdm_context;
+    const spdm_get_endpoint_info_request_t *spdm_request;
+    uint8_t encap_request[LIBSPDM_MAX_SPDM_MSG_SIZE];
+    size_t encap_request_size;
+    size_t index;
+    const uint8_t invalid_slot_id[] = { SPDM_MAX_SLOT_COUNT, 0xE, 0xFF };
+    const uint8_t valid_slot_id[] = { SPDM_MAX_SLOT_COUNT - 1, 0xF };
+
+    spdm_test_context = *state;
+    spdm_test_context->case_id = 0x8;
+    spdm_context = spdm_test_context->spdm_context;
+    spdm_context->connection_info.version = SPDM_MESSAGE_VERSION_13 <<
+                                            SPDM_VERSION_NUMBER_SHIFT_BIT;
+    spdm_context->connection_info.connection_state = LIBSPDM_CONNECTION_STATE_NEGOTIATED;
+    spdm_context->connection_info.capability.flags = 0;
+    spdm_context->connection_info.capability.flags |=
+        SPDM_GET_CAPABILITIES_REQUEST_FLAGS_EP_INFO_CAP_SIG;
+    spdm_context->last_spdm_request_session_id_valid = false;
+
+    for (index = 0; index < LIBSPDM_ARRAY_SIZE(invalid_slot_id); index++) {
+        spdm_context->encap_context.req_slot_id = 0;
+        spdm_context->encap_context.payload_buffer = NULL;
+
+        encap_request_size = sizeof(encap_request);
+        status = libspdm_get_encap_request_get_endpoint_info(
+            spdm_context, NULL, SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER,
+            invalid_slot_id[index], SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
+            sizeof(m_endpoint_info_buffer_send), m_endpoint_info_buffer_send,
+            &encap_request_size, encap_request);
+        assert_int_equal(status, LIBSPDM_STATUS_INVALID_PARAMETER);
+
+        /* Neither the slot nor the buffer was recorded. */
+        assert_int_equal(spdm_context->encap_context.req_slot_id, 0);
+        assert_null(spdm_context->encap_context.payload_buffer);
+    }
+
+    for (index = 0; index < LIBSPDM_ARRAY_SIZE(valid_slot_id); index++) {
+        libspdm_reset_message_encap_e(spdm_context, NULL);
+
+        encap_request_size = sizeof(encap_request);
+        status = libspdm_get_encap_request_get_endpoint_info(
+            spdm_context, NULL, SPDM_GET_ENDPOINT_INFO_REQUEST_SUBCODE_DEVICE_CLASS_IDENTIFIER,
+            valid_slot_id[index], SPDM_GET_ENDPOINT_INFO_REQUEST_ATTRIBUTE_SIGNATURE_REQUESTED,
+            sizeof(m_endpoint_info_buffer_send), m_endpoint_info_buffer_send,
+            &encap_request_size, encap_request);
+        assert_int_equal(status, LIBSPDM_STATUS_SUCCESS);
+        spdm_request = (const void *)encap_request;
+        assert_int_equal(spdm_request->header.param2, valid_slot_id[index]);
+        assert_int_equal(spdm_context->encap_context.req_slot_id, valid_slot_id[index]);
+    }
+
+    libspdm_reset_message_encap_e(spdm_context, NULL);
+    spdm_context->encap_context.req_slot_id = 0;
+    spdm_context->encap_context.payload_buffer = m_endpoint_info_buffer_send;
+}
+
 int libspdm_rsp_encap_get_endpoint_info_test(void)
 {
     const struct CMUnitTest test_cases[] = {
         /* Success request endpoint info with signature */
         cmocka_unit_test(rsp_encap_get_endpoint_info_case1),
-        /* Success request endpoint info with signature, req_slot_id = 0xFF */
+        /* Success request endpoint info with signature, req_slot_id = 0xF */
         cmocka_unit_test(rsp_encap_get_endpoint_info_case2),
         /* Success request endpoint info without signature */
         cmocka_unit_test(rsp_encap_get_endpoint_info_case3),
@@ -705,6 +773,8 @@ int libspdm_rsp_encap_get_endpoint_info_test(void)
         cmocka_unit_test(rsp_encap_get_endpoint_info_case6),
         /* More endpoint information is returned than the buffer can hold */
         cmocka_unit_test(rsp_encap_get_endpoint_info_case7),
+        /* The slot of the Requester's certificate chain is bounds-checked */
+        cmocka_unit_test(rsp_encap_get_endpoint_info_case8),
     };
 
     libspdm_test_context_t test_context = {


### PR DESCRIPTION
Validate slot_id/req_slot_id in encapsulated request builders. Add parameter checks to `libspdm_get_encap_request_challenge()`, `libspdm_get_encap_request_get_certificate()`, and `libspdm_get_encap_request_get_endpoint_info()` so invalid slot values return `LIBSPDM_STATUS_INVALID_PARAMETER`. Document the semantics (challenge accepts 0xFF for provisioned public key, endpoint-info uses 0xF as the 4-bit provisioned-key marker, certificate disallows 0xFF), update public headers and API docs, and add unit tests to exercise the new bounds checks and corrected endpoint-info marker.